### PR TITLE
use string keys for agent pool values

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,16 +106,16 @@ helm install capz1 charts/azure-managed-cluster/  \
 --set cluster.resourceGroupName=aksclusters \
 --set cluster.nodeResourceGroupName=capz1 \
 --set cluster.name=aks1 \
---set agentpools.0.name=capz1np0 \
---set agentpools.0.nodecount=1 \
---set agentpools.0.sku=Standard_B4ms \
---set agentpools.0.osDiskSizeGB=100 \
---set agentpools.0.mode=System \
---set agentpools.1.name=capz1np1 \
---set agentpools.1.nodecount=1 \
---set agentpools.1.sku=Standard_B4ms \
---set agentpools.1.osDiskSizeGB=10 \
---set agentpools.1.mode=User 
+--set agentpools.agentpool0.name=capz1np0 \
+--set agentpools.agentpool0.nodecount=1 \
+--set agentpools.agentpool0.sku=Standard_B4ms \
+--set agentpools.agentpool0.osDiskSizeGB=100 \
+--set agentpools.agentpool0.mode=System \
+--set agentpools.agentpool1.name=capz1np1 \
+--set agentpools.agentpool1.nodecount=1 \
+--set agentpools.agentpool1.sku=Standard_B4ms \
+--set agentpools.agentpool1.osDiskSizeGB=10 \
+--set agentpools.agentpool1.mode=User 
 ```
 
 or more simply (after you edit the values file with your own values):

--- a/aks1.yaml
+++ b/aks1.yaml
@@ -40,13 +40,13 @@ controlplane:
 
 #Only 1 Nodepool of mode System is allowed  
 agentpools:
- - name: capz1np0
-   mode: System
-   sku: Standard_B2s
-   nodecount: 1
-   osDiskSizeGB: 100
- - name: capz1np1
-   mode: User
-   nodecount: 1
-   sku: Standard_B2s
-   osDiskSizeGB: 100
+  capz1np0:
+    mode: System
+    sku: Standard_B2s
+    nodecount: 1
+    osDiskSizeGB: 100
+  capz1np1:
+    mode: User
+    nodecount: 1
+    sku: Standard_B2s
+    osDiskSizeGB: 100

--- a/article.md
+++ b/article.md
@@ -40,16 +40,16 @@ Ready to roll! Deploy your first cluster with Helm:
     --set cluster.nodeResourceGroupName=capz1 \
     --set cluster.name=aks1 \
     --set controlplane.sshPublicKey="$(cat ~/.ssh/id_rsa.pub)" \
-    --set agentpools.0.name=capz1np0 \
-    --set agentpools.0.nodecount=1 \
-    --set agentpools.0.sku=Standard_B4ms \
-    --set agentpools.0.osDiskSizeGB=100 \
-    --set agentpools.0.mode=System \
-    --set agentpools.1.name=capz1np1 \
-    --set agentpools.1.nodecount=1 \
-    --set agentpools.1.sku=Standard_B4ms \
-    --set agentpools.1.osDiskSizeGB=10 \
-    --set agentpools.1.mode=User 
+    --set agentpools.agentpool0.name=capz1np0 \
+    --set agentpools.agentpool0.nodecount=1 \
+    --set agentpools.agentpool0.sku=Standard_B4ms \
+    --set agentpools.agentpool0.osDiskSizeGB=100 \
+    --set agentpools.agentpool0.mode=System \
+    --set agentpools.agentpool1.name=capz1np1 \
+    --set agentpools.agentpool1.nodecount=1 \
+    --set agentpools.agentpool1.sku=Standard_B4ms \
+    --set agentpools.agentpool1.osDiskSizeGB=10 \
+    --set agentpools.agentpool1.mode=User 
 
 
 If you like you can use a values.yaml file:

--- a/charts/azure-managed-cluster/Chart.yaml
+++ b/charts/azure-managed-cluster/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/azure-managed-cluster/templates/agentpool.yaml
+++ b/charts/azure-managed-cluster/templates/agentpool.yaml
@@ -1,10 +1,10 @@
-{{- range $agentpools := .Values.agentpools }}
+{{- range $agentpoolsname, $agentpools := .Values.agentpools }}
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: AzureManagedMachinePool
 metadata:
-  name: {{ $agentpools.name }}
+  name: {{ $agentpoolsname }}
 spec:
-  name: {{ $agentpools.name }}
+  name: {{ $agentpoolsname }}
   scaling:
     minSize: {{ $agentpools.scaling.minSize }}
     maxSize: {{ $agentpools.scaling.maxSize }}
@@ -50,7 +50,7 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachinePool
 metadata:
-  name: {{ $agentpools.name }}
+  name: {{ $agentpoolsname }}
 spec:
   clusterName: {{ $.Values.cluster.name }}
   replicas: {{ $agentpools.nodecount }}
@@ -63,7 +63,7 @@ spec:
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: AzureManagedMachinePool
-        name: {{ $agentpools.name }}
+        name: {{ $agentpoolsname }}
         namespace: {{ $.Release.Namespace }}
       version: {{ $.Values.controlplane.kubernetes_version }}
 ---

--- a/charts/azure-managed-cluster/values.yaml
+++ b/charts/azure-managed-cluster/values.yaml
@@ -107,69 +107,69 @@ controlplane:
   disableLocalAccounts: false
 #Only 1 Nodepool of mode System is allowed  
 agentpools: 
- - name: agentpool0
-   mode: System
-   sku: Standard_D4d_v5
-   nodecount: 5
-   osDiskSizeGB: 100
-   additionalTags:
-    - key: test
-      value: test
-  #  availabilityZones: 
-  #   - "1"
-  #   - "2"
-  #   - "3"
-   nodeLabels:
-    - key: test
-      value: test 
-   taints: {}
-   scaling:
-      minSize: 1
-      maxSize: 5
-   maxPods: 110
-   osDiskType : "Ephemeral"
-   enableUltraSSD : false
-   osType : "Linux"
-   enableNodePublicIP : false
-   nodePublicIPPrefixID : ""
-   scaleSetPriority : "Regular"
-   scaleDownMode : "Delete"
-   spotMaxPrice : ""
-   kubeletConfig : ""
-   kubeletDiskType : "OS"
-   linuxOSConfig : "" 
-   subnetName : ""
-   enableFIPS : false
-   enableEncryptionAtHost : false 
- - name : agentpool1
-   mode: User
-   sku: Standard_D4d_v5
-   nodecount: 5
-   osDiskSizeGB: 100
-   additionalTags:
-    - key: test
-      value: test
-  #  availabilityZones: 
-  #   - "1"
-  #   - "2"
-  #   - "3"
-   nodeLabels:
-    - key: test
-      value: test 
-   taints: {}
-   scaling:
-      minSize: 1
-      maxSize: 5
-   maxPods: 110
-   osDiskType : "Ephemeral"
-   enableUltraSSD : false
-   osType : "Linux"
-   enableNodePublicIP : false
-   nodePublicIPPrefixID : ""
-   scaleSetPriority : "Regular"
-   scaleDownMode : "Delete"
-   spotMaxPrice : ""
-   kubeletConfig : ""
-   kubeletDiskType : "OS"
-   linuxOSConfig : "" 
-   subnetName : ""    
+  agentpool0:
+    mode: System
+    sku: Standard_D4d_v5
+    nodecount: 5
+    osDiskSizeGB: 100
+    additionalTags:
+     - key: test
+       value: test
+   #  availabilityZones: 
+   #   - "1"
+   #   - "2"
+   #   - "3"
+    nodeLabels:
+     - key: test
+       value: test 
+    taints: {}
+    scaling:
+       minSize: 1
+       maxSize: 5
+    maxPods: 110
+    osDiskType : "Ephemeral"
+    enableUltraSSD : false
+    osType : "Linux"
+    enableNodePublicIP : false
+    nodePublicIPPrefixID : ""
+    scaleSetPriority : "Regular"
+    scaleDownMode : "Delete"
+    spotMaxPrice : ""
+    kubeletConfig : ""
+    kubeletDiskType : "OS"
+    linuxOSConfig : "" 
+    subnetName : ""
+    enableFIPS : false
+    enableEncryptionAtHost : false 
+  agentpool1:
+    mode: User
+    sku: Standard_D4d_v5
+    nodecount: 5
+    osDiskSizeGB: 100
+    additionalTags:
+     - key: test
+       value: test
+   #  availabilityZones: 
+   #   - "1"
+   #   - "2"
+   #   - "3"
+    nodeLabels:
+     - key: test
+       value: test 
+    taints: {}
+    scaling:
+       minSize: 1
+       maxSize: 5
+    maxPods: 110
+    osDiskType : "Ephemeral"
+    enableUltraSSD : false
+    osType : "Linux"
+    enableNodePublicIP : false
+    nodePublicIPPrefixID : ""
+    scaleSetPriority : "Regular"
+    scaleDownMode : "Delete"
+    spotMaxPrice : ""
+    kubeletConfig : ""
+    kubeletDiskType : "OS"
+    linuxOSConfig : "" 
+    subnetName : ""    


### PR DESCRIPTION
This makes it possible to structure a values override file like this without having to specify all values for each agent pool:
```yaml
agentpools:
  agentpool0:
    maxPods: 999
  agentpool1:
    mode: System
```